### PR TITLE
Fix ES charset

### DIFF
--- a/Contents/mods/FuelAPI/media/lua/shared/Translate/ES/ItemName_ES.txt
+++ b/Contents/mods/FuelAPI/media/lua/shared/Translate/ES/ItemName_ES.txt
@@ -1,4 +1,4 @@
 ItemName_ES = {
-    ItemName_FuelAPI.LargePetrolCan = "Lata de gas grande vacÃ­a",
+    ItemName_FuelAPI.LargePetrolCan = "Lata de gas grande vacía",
     ItemName_FuelAPI.LargePetrolCanFull = "Lata de gas grande",
 }


### PR DESCRIPTION
Spanish traslation needs windows 1252 charset to work properly.

If not used the í char show as Ã­~.